### PR TITLE
Escape SSID and password in POST request

### DIFF
--- a/webConfigure.cpp
+++ b/webConfigure.cpp
@@ -175,7 +175,7 @@ void handleRoot() {
   html += "  var xhttp = new XMLHttpRequest();";
   html += "  xhttp.open('POST', '/ssid', true);";
   html += "  xhttp.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');";
-  html += "  xhttp.send('ssid=' + ssid);";
+  html += "  xhttp.send('ssid=' + encodeURIComponent(ssid));";
   html += "}";
 
   html += "function setPassword() {";
@@ -183,7 +183,7 @@ void handleRoot() {
   html += "  var xhttp = new XMLHttpRequest();";
   html += "  xhttp.open('POST', '/password', true);";
   html += "  xhttp.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');";
-  html += "  xhttp.send('password=' + password);";
+  html += "  xhttp.send('password=' + encodeURIComponent(password));";
   html += "}";
 
   html += "function reset() {";


### PR DESCRIPTION
If SSID or password contain any weird characters they may not be stored properly. Escape using `encodeURIComponent()` to make sure they are formatted properly before.

A better way to solve this would be to use `fetch()` with `FormData` which is the modern way to do HTTP requests but this requires some more work since the entire request function would be need to be rewritten.