### PR TITLE
Call `compass.read()` before reading azimuth

### DIFF
--- a/rotatorControllerESP8266.ino
+++ b/rotatorControllerESP8266.ino
@@ -91,6 +91,7 @@ int getAzimuth()
 {
 	int azimuth = 0;
 #ifdef COMPASS_OFFICAL
+	compass.read();
 	azimuth = compass.getAzimuth();
 #else
 	if ( compass.ready() )
@@ -689,6 +690,7 @@ void calculateDeclination()
 	int currentBearing;
 
 #ifdef COMPASS_OFFICAL
+	compass.read();
 	currentBearing = compass.getAzimuth();
 #else
 	currentBearing = compass.readHeading();


### PR DESCRIPTION
When using the QMC5883LCompass library, `compass.read()` must be called as it triggers a low-level read of the data, which is then returned by `compass.getAzimuth()` and possibly other calls.